### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,13 +7,17 @@ on:
 
 jobs:
   build-deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
 
       - name: Setup Flutter
-        uses: subosito/flutter-action@v1
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,20 @@
+name: PR review
+
+on:
+  pull_request:
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+      - name: Install dependencies
+        run: |
+          flutter pub get
+      - uses: invertase/github-action-dart-analyzer@v1


### PR DESCRIPTION
GitHub Actionsの改善PRです。

1. gh-pages
   * ubuntuのバージョンを固定する必要があまりないため、latestの指定に変更しました (https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners)
   * subosito/flutter-action@v2 に更新し、flutterのキャッシュを有効にしました
     * キャッシュによる、ビルド時間の高速化が見込めます
     * Flutterのバージョンが更新された時に問題が起きる恐れがあるので、たかだか1分程度の差なこともあり、対応しなくても良いかもしれません
       * https://github.com/subosito/flutter-action/pull/166
   * ビルド時に問題が起きた時のために、timeoutを10分で設定しました
2. pr-review
   * https://github.com/invertase/github-action-dart-analyzer を利用し、PR時にdart analyzerを動作させています
   * 外部コントリビューターとのやりとりの負担を軽減する目的です