### PR TITLE
show all member and scrolling disabled

### DIFF
--- a/lib/widgets/staff.dart
+++ b/lib/widgets/staff.dart
@@ -22,27 +22,21 @@ class StaffSection extends StatelessWidget {
           DividerWithTitle(text: appLocalizations.executive_committee),
           Container(
             alignment: Alignment.center,
-            child: SizedBox(
-                height: 400,
-                child: Center(
-                  child: GridView.extent(
-                    shrinkWrap: true,
-                    primary: false,
-                    padding: const EdgeInsets.all(24),
-                    crossAxisSpacing: 24,
-                    mainAxisSpacing: 24,
-                    maxCrossAxisExtent: 100,
-                    children: kStaffList
-                        .map(
-                          (e) => StaffItem(
-                            name: e['name'] ?? '',
-                            photo: e['photo'] ?? '',
-                            url: e['url'] ?? '',
-                          ),
-                        )
-                        .toList(),
-                  ),
-                )),
+            child: Wrap(
+              children: kStaffList
+                  .map(
+                    (e) => SizedBox(
+                      height: 128,
+                      width: 128,
+                      child: StaffItem(
+                        name: e['name'] ?? '',
+                        photo: e['photo'] ?? '',
+                        url: e['url'] ?? '',
+                      ),
+                    ),
+                  )
+                  .toList(),
+            ),
           ),
         ],
       ),


### PR DESCRIPTION
## summary
Improved on smart phones, only the staff scrolls separately and is hard to operate 👀 
Supported to show all staff and not scrolling.
please check it 🙏 

### before
 https://user-images.githubusercontent.com/885696/183285235-e9e7d42f-0c4a-47af-a664-46904764513e.mov 


### after
https://user-images.githubusercontent.com/885696/183285250-5e78a0e6-f267-4e42-abcf-66f0b8294d91.mov

