### PR TITLE
Add questionnaire link

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -76,8 +76,14 @@
     "source.organizeImports": true
   },
   "cSpell.words": [
+    "confwebsite",
+    "flutterkaigi",
+    "Fortee",
+    "Handson",
+    "Kaigi",
     "mockito",
-    "riverpod"
+    "riverpod",
+    "ultrawide"
   ],
 
   "peacock.color": "#03a9f4",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2,6 +2,7 @@
     "home": "Home",
     "event": "Past Events",
     "tweet": "Tweet",
+    "questionnaire": "Questionnaire",
     "letsTweet": "Tweet #FlutterKaigi!",
     "checkLatestNews": "Check our official Twitter account for the latest news!",
     "proposalSubmissionStart": "Talk Submission Has Started!",
@@ -36,5 +37,13 @@
     "disclaimer": "Flutter and the related logo are trademarks of Google LLC. FlutterKaigi is not affiliated with or otherwise sponsored by Google LLC.",
     "trademark" : "The \"Flutter\" name and the Flutter logo <FlutterLogo/> (the \"Flutter Marks\") are trademarks owned by Google.",
     "other_event": "Other events",
-    "back": "Go back"
+    "back": "Go back",
+    "questionnaireTitle": "FlutterKaigi 2022-DAY{day} questionnaire for attendee",
+    "@questionnaireTitle": {
+      "placeholders": {
+        "day": {
+          "type": "int"
+        }
+      }   
+    }
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -2,6 +2,7 @@
     "home": "ホーム",
     "event": "イベント",
     "tweet": "ツイート",
+    "questionnaire": "アンケート",
     "letsTweet": "#FlutterKaigi でツイートしよう！",
     "checkLatestNews": "最新情報は公式 Twitter アカウントをチェック！",
     "proposalSubmissionStart": "トーク募集開始！",
@@ -36,5 +37,13 @@
     "disclaimer": "Flutter and the related logo are trademarks of Google LLC. FlutterKaigi is not affiliated with or otherwise sponsored by Google LLC.",
     "trademark" : "The \"Flutter\" name and the Flutter logo <FlutterLogo/> (the \"Flutter Marks\") are trademarks owned by Google.",
     "other_event": "その他のイベント",
-    "back": "戻る"
+    "back": "戻る",
+    "questionnaireTitle": "FlutterKaigi 2022-DAY{day} 本編参加者アンケート",
+    "@questionnaireTitle": {
+      "placeholders": {
+        "day": {
+          "type": "int"
+        }
+      }   
+    }
 }

--- a/lib/widgets/features.dart
+++ b/lib/widgets/features.dart
@@ -18,3 +18,6 @@ const showSponsorLogo = true;
 
 /// 受付開始
 const startApply = true;
+
+/// アンケートリンク
+const questionnaireLinkEnabled = false;

--- a/lib/widgets/sessions.dart
+++ b/lib/widgets/sessions.dart
@@ -4,6 +4,7 @@ import 'package:confwebsite2022/entity/timetable_entity.dart';
 import 'package:confwebsite2022/responsive_layout_builder.dart';
 import 'package:confwebsite2022/theme.dart';
 import 'package:confwebsite2022/widgets/divider_with_title.dart';
+import 'package:confwebsite2022/widgets/features.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:gap/gap.dart';
@@ -28,6 +29,7 @@ final sessionList = FutureProvider((_) async {
 });
 
 final _selectedDayIndex = StateProvider((_) => 0);
+final _selectedDay = Provider((ref) => ref.watch(_selectedDayIndex) + 1);
 
 class SessionList extends ConsumerWidget {
   const SessionList({super.key});
@@ -97,6 +99,9 @@ class _SessionList extends ConsumerWidget {
             talk: () => _Talk(item: session),
           ),
           const Gap(16),
+        ],
+        if (questionnaireLinkEnabled) ...[
+          const _Questionnaire(),
         ],
       ],
     );
@@ -309,6 +314,60 @@ class _Talk extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+class _Questionnaire extends StatelessWidget {
+  const _Questionnaire();
+
+  @override
+  Widget build(BuildContext context) {
+    final appLocalizations = AppLocalizations.of(context)!;
+    return Center(
+      child: Column(
+        children: [
+          Text(
+            appLocalizations.questionnaire,
+            style: const TextStyle(
+              fontSize: 22,
+              fontWeight: FontWeight.bold,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const Gap(12),
+          const _QuestionnaireLink(),
+        ],
+      ),
+    );
+  }
+}
+
+class _QuestionnaireLink extends ConsumerWidget {
+  const _QuestionnaireLink();
+
+  static const _links = [
+    'https://docs.google.com/forms/d/e/1FAIpQLSfeNsyunlRhNt0bd3XBcc3-kZ6hPFeLtg7tE09_AGuTxIMkTw/viewform',
+    'https://docs.google.com/forms/d/e/1FAIpQLScdNsZqr-_FN0YpZTM3zy_C8G6ATVwh_BUPwbuGBSk6AvUQWQ/viewform',
+    'https://docs.google.com/forms/d/e/1FAIpQLSdWFsJzl1TwxtM9az_w6c5Fxgs0osXwYNxKAkE1HKOndFzU4g/viewform',
+  ];
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final appLocalizations = AppLocalizations.of(context)!;
+
+    final dayIndex = ref.watch(_selectedDayIndex);
+    assert(dayIndex < _links.length);
+
+    final day = ref.watch(_selectedDay);
+    return TextButton(
+      onPressed: () async {
+        await launch(
+          _links[dayIndex],
+          webOnlyWindowName: '_blank',
+        );
+      },
+      child: Text(appLocalizations.questionnaireTitle(day)),
     );
   }
 }

--- a/lib/widgets/sessions.dart
+++ b/lib/widgets/sessions.dart
@@ -12,7 +12,7 @@ import 'package:http/http.dart' as http;
 import 'package:intl/intl.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-const timeslotColor = Color(0x66F25D50);
+const timeSlotColor = Color(0x66F25D50);
 const talkColor = Color(0x666200EE);
 const sponsorColor = Color(0xffFFF275);
 
@@ -93,7 +93,7 @@ class _SessionList extends ConsumerWidget {
         const Gap(24),
         for (final session in division.values.elementAt(selectedDay)) ...[
           session.type.when(
-            timeslot: () => _Timeslot(item: session),
+            timeslot: () => _TimeSlot(item: session),
             talk: () => _Talk(item: session),
           ),
           const Gap(16),
@@ -203,10 +203,10 @@ String createSessionTimeRange(Timetable item) {
   return '${timeFormatter.format(startTime)} - ${timeFormatter.format(finishTime)}';
 }
 
-class _Timeslot extends StatelessWidget {
+class _TimeSlot extends StatelessWidget {
   final Timetable item;
 
-  const _Timeslot({
+  const _TimeSlot({
     Key? key,
     required this.item,
   }) : super(key: key);
@@ -218,7 +218,7 @@ class _Timeslot extends StatelessWidget {
     return Container(
       decoration: const BoxDecoration(
         border: Border.symmetric(
-          horizontal: BorderSide(color: timeslotColor, width: 2),
+          horizontal: BorderSide(color: timeSlotColor, width: 2),
         ),
       ),
       width: double.infinity,


### PR DESCRIPTION
## 🌈 Summary

- アンケートリンクをセッションリストの下部に配置

## 🎯 Details

- いくつかスペルチェッカーのignoreを追加
- `Timeslot` を `TimeSlot` に変更
- `_Questionnaire` を作成
 - インデックスではなく表示用に `_selectedDay` Providerを追加

## 📸 Images

| feature false | day1 | day2 | day3 |
| -- | -- | -- | -- |
<img width="1028" alt="CleanShot 2022-11-12 at 12 23 42@2x" src="https://user-images.githubusercontent.com/2792420/201454260-c6c66225-7fb7-4bed-9845-af1e8c482134.png"> | <img width="1036" alt="CleanShot 2022-11-12 at 12 28 01@2x" src="https://user-images.githubusercontent.com/2792420/201454286-197f522d-f698-40ac-9e81-edb9aba1401b.png"> | <img width="1033" alt="CleanShot 2022-11-12 at 12 28 18@2x" src="https://user-images.githubusercontent.com/2792420/201454292-941fc5dc-2e9e-4fe1-8da4-61f4bef1c9d3.png"> | <img width="1045" alt="CleanShot 2022-11-12 at 12 28 39@2x" src="https://user-images.githubusercontent.com/2792420/201454300-df3b5a8b-1e77-4d44-931e-c85faf5f1322.png">